### PR TITLE
Add `-x` arg to cherry-pick.

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ ${ssh.split(' ').join('\n')}
    if (request.body.ref === 'refs/heads/master') {
        request.body.commits.forEach(commit => {
         //execSync(`cat ${JSON.stringify(commit)}`);
-        execSync(`cd /tmp/data-orbit && git checkout beta && git cherry-pick ${commit.id}   && git push origin beta`, { encoding: 'utf8', stdio: 'inherit' })
+        execSync(`cd /tmp/data-orbit && git checkout beta && git cherry-pick -x ${commit.id}   && git push origin beta`, { encoding: 'utf8', stdio: 'inherit' })
        });
    }
    return request.body;


### PR DESCRIPTION
The `-x` arg automatically adds some additional text to the new commit so that it is possible to track the original commit.

Take a look at this commit as an example:

https://github.com/emberjs/ember.js/commit/4ee04154c6fd3ef7ffd7b64944e20177752286c2

With the message added by `-x` it is possible to navigate easily to the original commit then to the original proposing PR, without `-x` context it is quite difficult (you have to search based on commit message text alone).